### PR TITLE
Add optional directory prop

### DIFF
--- a/assets/BaseTemplate/index.js
+++ b/assets/BaseTemplate/index.js
@@ -2,6 +2,8 @@
 module.exports = {
 
     name: "Base template",
+    
+    directory: false,
 
     params: ["Name", "Body"],
 

--- a/lib/select-view.coffee
+++ b/lib/select-view.coffee
@@ -35,16 +35,24 @@ class ParamSelectView extends View
   onConfirm: ->
 
     cfg = {}
+    nameParam = ''
 
     for param in (@template.params ? [])
       cfg[param] = @[param+"Editor"].getText()
+
+      if param == 'Name' && @template.directory
+
+        if cfg[param].length > 0
+          nameParam = cfg[param].replace(/\s+/g, '-').toLowerCase()
+        else
+          nameParam = @template.name.replace(/\s+/g, '-').toLowerCase()
 
     for rule in ((@template.rules?(cfg).items) ? [])
       continue unless rule.destinationFile
 
       if rule.sourceContentFile
         fullPathToTemplateFile = path.join @template.rootPath, rule.sourceContentFile
-        fullPathToNewFile      = path.join @targetPath, rule.destinationFile
+        fullPathToNewFile      = path.join @targetPath, nameParam, rule.destinationFile
         try
           fsPlus.makeTreeSync( path.dirname(fullPathToNewFile) )
           fsExtra.copySync fullPathToTemplateFile, fullPathToNewFile
@@ -53,7 +61,7 @@ class ParamSelectView extends View
 
       if rule.sourceTemplateFile
         fullPathToTemplateFile = path.join @template.rootPath, rule.sourceTemplateFile
-        fullPathToNewFile      = path.join @targetPath, rule.destinationFile
+        fullPathToNewFile      = path.join @targetPath, nameParam, rule.destinationFile
 
         try
           fsPlus.makeTreeSync( path.dirname(fullPathToNewFile) )


### PR DESCRIPTION
This PR adds an optional directory property to template options. If enabled, while creating files from template, there will be a parent directory created as well. It's name will be same as the "Name" parameter set - if available. Otherwise, it'll take the name of the template itself.